### PR TITLE
Prepare for 2017-10-23 (Brian Goetz)

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,12 +68,14 @@
 			         data-notes="^Note:"  
 			         data-charset="iso-8859-15"
 			    ></section>
+			    <!--
 			    <section data-markdown="sections/speaker-guest.md"
 			         data-separator="--slide--"  
 			         data-vertical="--section--"  
 			         data-notes="^Note:"
 			         data-charset="iso-8859-15"
 			    ></section>
+			    -->
 			    <section data-markdown="sections/speaker.md"
 			         data-separator="--slide--"  
 			         data-vertical="--section--"  

--- a/sections/cjug.md
+++ b/sections/cjug.md
@@ -1,9 +1,9 @@
 ## Chicago Java Users Group
 
-October 10, 2017
+October 23, 2017
 
-##Steve Poole Presents
-##Java in the 21 Century: Are you thinking far enough ahead?
+##GOTO NIGHTS with Brian Goetz
+##Java Language &amp; Platform Futures: A Sneak Peek
 
 
 <div style="background-color: white; margin-top: 30px;">
@@ -39,18 +39,18 @@ Tell your friends, family and co-workers.
 ## Upcoming CJUG Events
 <table class="upcoming-events"  width=800>
 <tr>
-  <td width=150>Oct 23</td>
+  <td width=150>Nov 9</td>
   <td>
-    GOTO NIGHTS with Brian Goetz<br/>
-    Java Language &amp; Platform Futures: A Sneak Peek<br/>
+    Matt Sicker Presents<br/>
+    The Why and How of Logging<br/>
     <br/>
-    @ CME Group
+    @ SPR Inc
   </td>
 </tr>
 </table>
 
 Note:
-CME Group is 20 S. Wacker
+SPR is at 233 South Wacker Drive
 
 --section--
 #CJUG Office Hours!

--- a/sections/cjug.md
+++ b/sections/cjug.md
@@ -58,7 +58,7 @@ SPR is at 233 South Wacker Drive
 * Talk about problems/shop/tech
 * Janine &amp; Todd (Mentors)
 * Next!
-  * October 25 @ TBD
+  * October 25 @ Spantree
   * Optional group project is Intro to Github!
 
 Note:

--- a/sections/speaker.md
+++ b/sections/speaker.md
@@ -1,8 +1,7 @@
 ## Featured Speaker: 
 
-### Steve Poole
-* Developer advocate, DevOps practitioner, and long time IBM Java developer
-* Has worked on IBM Java SDKs and JVMs since Java was less than one year old
-* Contributions to many open source projects and JSRs
-* Regular speaker and presenter at JavaOne, Devoxx, and other conferences
-
+### Brian Goetz
+* The Java Language Architect at Oracle
+* Specification lead for JSR-335 (Lambda Expressions)
+* Principal Author of <u>Java Concurrency in Practice</u>
+* International speaker and author of many articles

--- a/sections/sponsors.md
+++ b/sections/sponsors.md
@@ -1,4 +1,4 @@
 # Sponsors
 
-<img src="images/8thlight.png" style="border:none; box-shadow:none; margin: 30px; background:white"/>
+<img src="images/CME-Group-logo.jpg" style="border:none; box-shadow:none; margin: 30px; background:white"/>
 


### PR DESCRIPTION
+ Remove temporary guest speaker slide.
+ Add things about Brian Goetz.
+ Add Matt Sicker's talk.
+ Office hours on 2017-10-25 is at Spantree